### PR TITLE
Factor out testing of inner calls; separate test for 'satellite_common'.

### DIFF
--- a/iris_grib/_load_convert.py
+++ b/iris_grib/_load_convert.py
@@ -1653,14 +1653,15 @@ def time_coords(section, metadata, rt_coord):
     metadata['aux_coords_and_dims'].append((rt_coord, None))
 
 
-def generating_process(section):
+def generating_process(section, include_forecast_process=True):
     if options.warn_on_unsupported:
         # Reference Code Table 4.3.
         warnings.warn('Unable to translate type of generating process.')
         warnings.warn('Unable to translate background generating '
                       'process identifier.')
-        warnings.warn('Unable to translate forecast generating '
-                      'process identifier.')
+        if include_forecast_process:
+            warnings.warn('Unable to translate forecast generating '
+                          'process identifier.')
 
 
 def data_cutoff(hoursAfterDataCutoff, minutesAfterDataCutoff):
@@ -2042,10 +2043,7 @@ def product_definition_template_31(section, metadata, rt_coord):
         The scalar observation time :class:`iris.coords.DimCoord'.
 
     """
-    if options.warn_on_unsupported:
-        warnings.warn('Unable to translate type of generating process.')
-        warnings.warn('Unable to translate observation generating '
-                      'process identifier.')
+    generating_process(section, include_forecast_process=False)
 
     satellite_common(section, metadata)
 
@@ -2073,10 +2071,7 @@ def product_definition_template_32(section, metadata, rt_coord):
         The scalar observation time :class:`iris.coords.DimCoord'.
 
     """
-    if options.warn_on_unsupported:
-        warnings.warn('Unable to translate type of generating process.')
-        warnings.warn('Unable to translate observation generating '
-                      'process identifier.')
+    generating_process(section, include_forecast_process=False)
 
     # Handle the data cutoff.
     data_cutoff(section['hoursAfterDataCutoff'],

--- a/iris_grib/tests/unit/load_convert/test_generating_process.py
+++ b/iris_grib/tests/unit/load_convert/test_generating_process.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2014 - 2016, Met Office
+# (C) British Crown Copyright 2014 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -38,18 +38,30 @@ class TestGeneratingProcess(tests.IrisGribTest):
         generating_process(None)
         self.assertEqual(self.warn_patch.call_count, 0)
 
-    def test_warn(self):
+    def _check_warnings(self, with_forecast=True):
         module = 'iris_grib._load_convert'
         self.patch(module + '.options.warn_on_unsupported', True)
-        generating_process(None)
+        call_args = [None]
+        call_kwargs = {}
+        expected_fragments = [
+            'Unable to translate type of generating process',
+            'Unable to translate background generating process']
+        if with_forecast:
+            expected_fragments.append(
+                'Unable to translate forecast generating process')
+        else:
+            call_kwargs['include_forecast_process'] = False
+        generating_process(*call_args, **call_kwargs)
         got_msgs = [call[0][0] for call in self.warn_patch.call_args_list]
-        expected_msgs = ['Unable to translate type of generating process',
-                         'Unable to translate background generating process',
-                         'Unable to translate forecast generating process']
-        for expect_msg in expected_msgs:
-            matches = [msg for msg in got_msgs if expect_msg in msg]
-            self.assertEqual(len(matches), 1)
-            got_msgs.remove(matches[0])
+        for got_msg, expected_fragment in zip(sorted(got_msgs),
+                                              sorted(expected_fragments)):
+            self.assertIn(expected_fragment, got_msg)
+
+    def test_warn_full(self):
+        self._check_warnings()
+
+    def test_warn_no_forecast(self):
+        self._check_warnings(with_forecast=False)
 
 
 if __name__ == '__main__':

--- a/iris_grib/tests/unit/load_convert/test_product_definition_template_10.py
+++ b/iris_grib/tests/unit/load_convert/test_product_definition_template_10.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2016, Met Office
+# (C) British Crown Copyright 2016 - 2017, Met Office
 #
 # This file is part of iris-grib.
 #
@@ -31,7 +31,7 @@ import mock
 
 from iris.coords import DimCoord
 from iris_grib._load_convert import product_definition_template_10
-from iris.tests.unit.fileformats.grib.load_convert import empty_metadata
+from iris_grib.tests.unit.load_convert import empty_metadata
 
 
 class Test(tests.IrisGribTest):


### PR DESCRIPTION
Just to tidy up a bit and avoid some of the growing boilerplate legacy.